### PR TITLE
feat: added kafka consumer and simple event processor service

### DIFF
--- a/services/event-processor/Models/Configuration.cs
+++ b/services/event-processor/Models/Configuration.cs
@@ -1,20 +1,25 @@
 namespace EventProcessor.Models;
 
-public class ProcessorConfiguration
-{
-  public KafkaConfiguration Kafka { get; set; } = new();
-  public RedisConfiguration Redis { get; set; } = new();
-  public SqlServerConfiguration SqlServer { get; set; } = new();
-  public ProcessingConfiguration Processing { get; set; } = new();
-}
-
 public class KafkaConfiguration
 {
-  public string BootstrapServers { get; set; } = "localhost:9092";
+  public bool Enabled { get; set; } = true;
+  public string[] Brokers { get; set; } = ["localhost:9092"];
   public string Topic { get; set; } = "analytics-events";
   public string GroupId { get; set; } = "event-processor";
   public string ClientId { get; set; } = "event-processor-consumer";
-  public bool AutoOffsetReset { get; set; } = true;
+  public int SessionTimeoutMs { get; set; } = 30000;
+  public int PollTimeoutMs { get; set; } = 100;
+  public string AutoOffsetReset { get; set; } = "earliest";
+}
+
+public class ProcessorConfiguration
+{
+  public KafkaConfiguration Kafka { get; set; } = new();
+  public int MaxRetries { get; set; } = 3;
+  public int RetryDelayMs { get; set; } = 1000;
+  public bool EnableBatching { get; set; } = true;
+  public int BatchSize { get; set; } = 100;
+  public int BatchTimeoutMs { get; set; } = 5000;
 }
 
 public class RedisConfiguration

--- a/services/event-processor/Models/Event.cs
+++ b/services/event-processor/Models/Event.cs
@@ -16,18 +16,24 @@ public class EventData
 
 public enum EventType
 {
+  [JsonPropertyName("click")]
   Click,
+  [JsonPropertyName("page_view")]
   PageView,
+  [JsonPropertyName("purchase")]
   Purchase,
+  [JsonPropertyName("add_to_cart")]
   AddToCart,
+  [JsonPropertyName("checkout")]
   Checkout,
+  [JsonPropertyName("favorite")]
   Favorite,
+  [JsonPropertyName("add_review")]
   AddReview,
 }
 
-public enum TimeFrame
+public enum TimeWindow
 {
-  PerMinute,
   Hourly,
   Daily
 }
@@ -38,7 +44,7 @@ public class EventAggregation
   public long Count { get; set; }
   public double TotalValue { get; set; }
   public DateTime LastUpdated { get; set; }
-  public TimeFrame TimeWindow { get; set; }
+  public TimeWindow TimeWindow { get; set; }
   public DateTime WindowStart { get; set; }
 }
 

--- a/services/event-processor/Program.cs
+++ b/services/event-processor/Program.cs
@@ -1,24 +1,65 @@
-﻿using System.Net.WebSockets;
-using System.Text;
-using System.Text.Json;
+﻿using EventProcessor.Models;
+using EventProcessor.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace EventProcessor;
 
 public class Program
 {
-
   public static async Task Main(string[] args)
   {
+    var host = CreateHostBuilder(args).Build();
 
+    var logger = host.Services.GetRequiredService<ILogger<Program>>();
+    logger.LogInformation("Starting Event Processor Application");
+
+    try
+    {
+      await host.RunAsync();
+    }
+    catch (Exception ex)
+    {
+      logger.LogCritical(ex, "Application terminated unexpectedly");
+      throw;
+    }
+    finally
+    {
+      logger.LogInformation("Event Processor Application stopped");
+    }
   }
 
-  private static async Task ListenForEvents()
-  {
+  private static IHostBuilder CreateHostBuilder(string[] args) =>
+      Host.CreateDefaultBuilder(args)
+          .ConfigureAppConfiguration((context, config) =>
+          {
+            config.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true);
+            config.AddEnvironmentVariables();
+            config.AddCommandLine(args);
+          })
+          .ConfigureServices((context, services) =>
+          {
+            // Configure ProcessorConfiguration
+            services.Configure<ProcessorConfiguration>(
+                  context.Configuration.GetSection("ProcessorConfiguration"));
 
-  }
+            // Register services
+            services.AddSingleton<IEventProcessor, Services.EventProcessor>();
+            services.AddHostedService<KafkaConsumerService>();
 
-  private static async Task ProcessEvent()
-  {
-
-  }
+            // Configure logging
+            services.AddLogging(builder =>
+              {
+                builder.AddConsole();
+                builder.AddDebug();
+              });
+          })
+          .ConfigureLogging((context, logging) =>
+          {
+            logging.ClearProviders();
+            logging.AddConsole();
+            logging.AddDebug();
+          });
 }

--- a/services/event-processor/Services/EventProcessor.cs
+++ b/services/event-processor/Services/EventProcessor.cs
@@ -1,0 +1,192 @@
+using EventProcessor.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Collections.Concurrent;
+
+namespace EventProcessor.Services;
+
+public class EventProcessor : IEventProcessor
+{
+  private readonly ILogger<EventProcessor> _logger;
+  private readonly ProcessorConfiguration _config;
+
+  // In-memory storage for demo purposes - in production, use Redis/Database
+  private readonly ConcurrentDictionary<string, UserMetrics> _userMetrics = new();
+  private readonly ConcurrentDictionary<string, EventAggregation> _aggregations = new();
+
+  public EventProcessor(ILogger<EventProcessor> logger, IOptions<ProcessorConfiguration> config)
+  {
+    _logger = logger;
+    _config = config.Value;
+  }
+
+  public async Task ProcessEventAsync(EventData eventData, CancellationToken cancellationToken = default)
+  {
+    _logger.LogInformation("Processing event: {EventType} for user {UserId} at {Timestamp}",
+        eventData.EventType, eventData.UserId, DateTimeOffset.FromUnixTimeMilliseconds(eventData.Timestamp));
+
+    try
+    {
+      // Update user metrics
+      await UpdateUserMetricsAsync(eventData, cancellationToken);
+
+      // Update aggregations
+      await UpdateAggregationsAsync(eventData, cancellationToken);
+
+      // Log additional event details
+      if (eventData.Metadata.Count > 0)
+      {
+        _logger.LogDebug("Event metadata: {Metadata}",
+            string.Join(", ", eventData.Metadata.Select(kvp => $"{kvp.Key}: {kvp.Value}")));
+      }
+
+      // Simulate processing delay (remove in production)
+      await Task.Delay(50, cancellationToken);
+
+      _logger.LogInformation("Successfully processed event {EventType} for user {UserId}",
+          eventData.EventType, eventData.UserId);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Error processing event {EventType} for user {UserId}",
+          eventData.EventType, eventData.UserId);
+      throw;
+    }
+  }
+
+  public async Task<EventAggregation> GetAggregationAsync(EventType eventType, TimeWindow timeWindow, CancellationToken cancellationToken = default)
+  {
+    await Task.CompletedTask; // Simulate async operation
+
+    var key = $"{eventType}_{timeWindow}_{GetWindowStart(timeWindow)}";
+
+    if (_aggregations.TryGetValue(key, out var aggregation))
+    {
+      return aggregation;
+    }
+
+    // Return default aggregation if not found
+    return new EventAggregation
+    {
+      EventType = eventType,
+      Count = 0,
+      TotalValue = 0,
+      LastUpdated = DateTime.UtcNow,
+      TimeWindow = timeWindow,
+      WindowStart = GetWindowStart(timeWindow)
+    };
+  }
+
+  public async Task<UserMetrics> GetUserMetricsAsync(string userId, CancellationToken cancellationToken = default)
+  {
+    await Task.CompletedTask; // Simulate async operation
+
+    if (_userMetrics.TryGetValue(userId, out var metrics))
+    {
+      return metrics;
+    }
+
+    // Return default metrics if user not found
+    return new UserMetrics
+    {
+      UserId = userId,
+      TotalEvents = 0,
+      PageViews = 0,
+      Purchases = 0,
+      TotalSpent = 0,
+      LastActivity = DateTime.UtcNow,
+      EventCounts = new Dictionary<EventType, long>()
+    };
+  }
+
+  private async Task UpdateUserMetricsAsync(EventData eventData, CancellationToken cancellationToken)
+  {
+    await Task.CompletedTask; // Simulate async operation
+
+    var metrics = _userMetrics.GetOrAdd(eventData.UserId, _ => new UserMetrics
+    {
+      UserId = eventData.UserId,
+      EventCounts = new Dictionary<EventType, long>()
+    });
+
+    // Update metrics
+    metrics.TotalEvents++;
+    metrics.LastActivity = DateTimeOffset.FromUnixTimeMilliseconds(eventData.Timestamp).DateTime;
+
+    // Update event type counts
+    metrics.EventCounts[eventData.EventType] = metrics.EventCounts.GetValueOrDefault(eventData.EventType, 0) + 1;
+
+    // Update specific metrics based on event type
+    switch (eventData.EventType)
+    {
+      case EventType.PageView:
+        metrics.PageViews++;
+        break;
+      case EventType.Purchase:
+        metrics.Purchases++;
+        if (eventData.Metadata.TryGetValue("amount", out var amount) &&
+            double.TryParse(amount?.ToString(), out var purchaseAmount))
+        {
+          metrics.TotalSpent += purchaseAmount;
+        }
+        break;
+    }
+
+    _logger.LogDebug("Updated metrics for user {UserId}: {TotalEvents} total events",
+        eventData.UserId, metrics.TotalEvents);
+  }
+
+  private async Task UpdateAggregationsAsync(EventData eventData, CancellationToken cancellationToken)
+  {
+    await Task.CompletedTask; // Simulate async operation
+
+    // Update hourly aggregation
+    await UpdateAggregationForWindow(eventData, TimeWindow.Hourly, cancellationToken);
+
+    // Update daily aggregation
+    await UpdateAggregationForWindow(eventData, TimeWindow.Daily, cancellationToken);
+  }
+
+  private async Task UpdateAggregationForWindow(EventData eventData, TimeWindow timeWindow, CancellationToken cancellationToken)
+  {
+    await Task.CompletedTask; // Simulate async operation
+
+    var windowStart = GetWindowStart(timeWindow);
+    var key = $"{eventData.EventType}_{timeWindow}_{windowStart:yyyy-MM-dd-HH}";
+
+    var aggregation = _aggregations.GetOrAdd(key, _ => new EventAggregation
+    {
+      EventType = eventData.EventType,
+      Count = 0,
+      TotalValue = 0,
+      TimeWindow = timeWindow,
+      WindowStart = windowStart,
+      LastUpdated = DateTime.UtcNow
+    });
+
+    // Update aggregation
+    aggregation.Count++;
+    aggregation.LastUpdated = DateTime.UtcNow;
+
+    // Add value if present in metadata
+    if (eventData.Metadata.TryGetValue("amount", out var amount) &&
+        double.TryParse(amount?.ToString(), out var value))
+    {
+      aggregation.TotalValue += value;
+    }
+
+    _logger.LogDebug("Updated {TimeWindow} aggregation for {EventType}: {Count} events",
+        timeWindow, eventData.EventType, aggregation.Count);
+  }
+
+  private static DateTime GetWindowStart(TimeWindow timeWindow)
+  {
+    var now = DateTime.UtcNow;
+    return timeWindow switch
+    {
+      TimeWindow.Hourly => new DateTime(now.Year, now.Month, now.Day, now.Hour, 0, 0, DateTimeKind.Utc),
+      TimeWindow.Daily => new DateTime(now.Year, now.Month, now.Day, 0, 0, 0, DateTimeKind.Utc),
+      _ => now
+    };
+  }
+}

--- a/services/event-processor/Services/IEventProcessor.cs
+++ b/services/event-processor/Services/IEventProcessor.cs
@@ -1,0 +1,10 @@
+using EventProcessor.Models;
+
+namespace EventProcessor.Services;
+
+public interface IEventProcessor
+{
+  Task ProcessEventAsync(EventData eventData, CancellationToken cancellationToken = default);
+  Task<EventAggregation> GetAggregationAsync(EventType eventType, TimeWindow timeWindow, CancellationToken cancellationToken = default);
+  Task<UserMetrics> GetUserMetricsAsync(string userId, CancellationToken cancellationToken = default);
+}

--- a/services/event-processor/Services/KafkaConsumerService.cs
+++ b/services/event-processor/Services/KafkaConsumerService.cs
@@ -1,0 +1,147 @@
+using Confluent.Kafka;
+using EventProcessor.Models;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace EventProcessor.Services;
+
+public class KafkaConsumerService : BackgroundService
+{
+  private readonly ILogger<KafkaConsumerService> _logger;
+  private readonly ProcessorConfiguration _config;
+  private readonly IEventProcessor _eventProcessor;
+  private IConsumer<string, string>? _consumer;
+
+  public KafkaConsumerService(
+      ILogger<KafkaConsumerService> logger,
+      IOptions<ProcessorConfiguration> config,
+      IEventProcessor eventProcessor)
+  {
+    _logger = logger;
+    _config = config.Value;
+    _eventProcessor = eventProcessor;
+  }
+
+  protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+  {
+    if (!_config.Kafka.Enabled)
+    {
+      _logger.LogInformation("Kafka consumer is disabled");
+      return;
+    }
+
+    _logger.LogInformation("Starting Kafka consumer service");
+
+    var consumerConfig = new ConsumerConfig
+    {
+      BootstrapServers = string.Join(",", _config.Kafka.Brokers),
+      GroupId = _config.Kafka.GroupId,
+      ClientId = _config.Kafka.ClientId,
+      AutoOffsetReset = _config.Kafka.AutoOffsetReset == "earliest" ? AutoOffsetReset.Earliest : AutoOffsetReset.Latest,
+      SessionTimeoutMs = _config.Kafka.SessionTimeoutMs,
+      EnableAutoCommit = false, // Manual commit for better control
+      EnablePartitionEof = false,
+      AllowAutoCreateTopics = true
+    };
+
+    _consumer = new ConsumerBuilder<string, string>(consumerConfig)
+        .SetErrorHandler((_, e) => _logger.LogError("Consumer error: {Error}", e.Reason))
+        .SetStatisticsHandler((_, json) => _logger.LogDebug("Consumer stats: {Stats}", json))
+        .Build();
+
+    try
+    {
+      _consumer.Subscribe(_config.Kafka.Topic);
+      _logger.LogInformation("Subscribed to topic: {Topic}", _config.Kafka.Topic);
+
+      while (!stoppingToken.IsCancellationRequested)
+      {
+        try
+        {
+          var result = _consumer.Consume(TimeSpan.FromMilliseconds(_config.Kafka.PollTimeoutMs));
+
+          if (result != null)
+          {
+            await ProcessMessage(result, stoppingToken);
+
+            // Commit the offset after successful processing
+            _consumer.Commit(result);
+          }
+        }
+        catch (ConsumeException ex)
+        {
+          _logger.LogError(ex, "Error consuming message: {Error}", ex.Error.Reason);
+        }
+        catch (OperationCanceledException)
+        {
+          _logger.LogInformation("Kafka consumer operation was cancelled");
+          break;
+        }
+        catch (Exception ex)
+        {
+          _logger.LogError(ex, "Unexpected error in Kafka consumer");
+          await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+        }
+      }
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Fatal error in Kafka consumer service");
+    }
+    finally
+    {
+      _consumer?.Close();
+      _consumer?.Dispose();
+    }
+  }
+
+  private async Task ProcessMessage(ConsumeResult<string, string> result, CancellationToken cancellationToken)
+  {
+    try
+    {
+      _logger.LogDebug("Processing message from partition {Partition}, offset {Offset}",
+          result.Partition.Value, result.Offset.Value);
+
+      // Deserialize the event data
+      var options = new JsonSerializerOptions
+      {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.SnakeCaseLower) }
+      };
+      var eventData = JsonSerializer.Deserialize<EventData>(result.Message.Value, options);
+
+      if (eventData == null)
+      {
+        _logger.LogWarning("Failed to deserialize event data from message: {Message}", result.Message.Value);
+        return;
+      }
+
+      // Process the event
+      await _eventProcessor.ProcessEventAsync(eventData, cancellationToken);
+
+      _logger.LogInformation("Successfully processed event {EventType} for user {UserId}",
+          eventData.EventType, eventData.UserId);
+    }
+    catch (JsonException ex)
+    {
+      _logger.LogError(ex, "Failed to deserialize message: {Message}", result.Message.Value);
+    }
+    catch (Exception ex)
+    {
+      _logger.LogError(ex, "Error processing message: {Message}", result.Message.Value);
+      throw; // Re-throw to handle retry logic at a higher level
+    }
+  }
+
+  public override async Task StopAsync(CancellationToken cancellationToken)
+  {
+    _logger.LogInformation("Stopping Kafka consumer service");
+
+    _consumer?.Close();
+
+    await base.StopAsync(cancellationToken);
+  }
+}

--- a/services/event-processor/appsettings.json
+++ b/services/event-processor/appsettings.json
@@ -1,0 +1,29 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "EventProcessor": "Debug"
+    }
+  },
+  "ProcessorConfiguration": {
+    "Kafka": {
+      "Enabled": true,
+      "Brokers": [
+        "localhost:9092"
+      ],
+      "Topic": "analytics-events",
+      "GroupId": "event-processor",
+      "ClientId": "event-processor-consumer",
+      "SessionTimeoutMs": 30000,
+      "PollTimeoutMs": 100,
+      "AutoOffsetReset": "earliest"
+    },
+    "MaxRetries": 3,
+    "RetryDelayMs": 1000,
+    "EnableBatching": true,
+    "BatchSize": 100,
+    "BatchTimeoutMs": 5000
+  }
+}

--- a/services/event-processor/event-processor.csproj
+++ b/services/event-processor/event-processor.csproj
@@ -8,4 +8,18 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Confluent.Kafka" Version="2.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
# Add Kafka Consumer to Event Processor Service
## Changes
- Added Kafka integration to event-processor service for consuming analytics events
- New services: KafkaConsumerService and EventProcessor for real-time event processing
- Configuration: Added appsettings.json and configuration models for Kafka settings
- Dependencies: Added Confluent.Kafka and Microsoft.Extensions packages
- Event processing: Processes events and maintains user metrics and aggregations in memory
- Updated models: Fixed EventType enum serialization to match event-generator format

## Files modified
```
services/event-processor/
├── event-processor.csproj         # Added Kafka dependencies
├── Program.cs                     # Setup DI and background service
├── appsettings.json               # Kafka configuration
├── Models/
│   ├── Configuration.cs           # Kafka config classes
│   └── Event.cs                   # Updated enum serialization
└── Services/
    ├── KafkaConsumerService.cs    # Background Kafka consumer
    ├── IEventProcessor.cs         # Processing interface
    └── EventProcessor.cs          # Event processing logic
```

## Usage
```bash
# Start infrastructure
docker-compose up -d kafka

# Run event processor
cd services/event-processor && dotnet run

# Run event generator (separate terminal)
cd services/event-generator && pnpm run start
```